### PR TITLE
Fix main in package.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@triptease-paid-search:registry=https://us-npm.pkg.dev/triptease-paid-search/tt-paid-search/
+//us-npm.pkg.dev/triptease-paid-search/tt-paid-search/:always-auth=true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 A lightweight HTTP framework for Typescript / JS, with zero dependencies
 
+This is a fork, since the original appears unmaintained. This gets deployed into:
+
+https://us-npm.pkg.dev/triptease-paid-search/tt-paid-search/
+
+The commands I ran for publishing
+* everything under release.sh up until the `npm publish` command
+* `npm config set registry https://us-npm.pkg.dev/triptease-paid-search/tt-paid-search/`
+* Went into the paid-search repo and ran: `yarn artifactregistry-login`
+* `npm publish` from inside the dist folder
+
+
 # >> [read the docs :)](https://tomshacham.github.io/http4js/) <<
 
 ## Use http4js in your project

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "http4js",
   "version": "5.0.7",
   "description": "A lightweight HTTP toolkit",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "tsc; mocha --require ts-node/register 'src/{test,ssl}/**/*.ts'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triptease-paid-search/http4js",
-  "version": "5.0.7.1",
+  "version": "5.0.7-2",
   "description": "A lightweight HTTP toolkit",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "http4js",
-  "version": "5.0.7",
+  "name": "@triptease-paid-search/http4js",
+  "version": "5.0.7.1",
   "description": "A lightweight HTTP toolkit",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/main/core/Uri.ts
+++ b/src/main/core/Uri.ts
@@ -18,7 +18,7 @@ export class Uri {
     asNativeNodeRequest: NodeURI;
     matches: KeyValues;
     private pathParamMatchingRegex: RegExp = new RegExp(/\{(\w+)\}/g);
-    private pathParamCaptureTemplate: string = "([\\w\\s\-\%]+)";
+    private pathParamCaptureTemplate: string = "([\\w\\s\-\%\&]+)";
 
 
     constructor(template: string, matches: KeyValues = {}) {


### PR DESCRIPTION
Our logs have many instances of the following:

> [DEP0128] DeprecationWarning: Invalid 'main' field in '/usr/src/app/node_modules/http4js/package.json' of 'dist/index.js'. Please either fix that or report it to the module author

Since there's no dist folder in the package, I assume the path is wrong for both **main** and **types**. This addresses that.